### PR TITLE
Typescript types for it.nock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,5 +17,5 @@ type Options = {
     nockOptions?: nock.Options;
 };
 
-export function upgradeJasmine(global: NodeJS.Global, options?: Options): void;
-export function upgradeCircus(global: NodeJS.Global, options?: Options): void;
+export function upgradeJasmine(global: typeof globalThis, options?: Options): void;
+export function upgradeCircus(global: typeof globalThis, options?: Options): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,3 +18,4 @@ type Options = {
 };
 
 export function upgradeJasmine(global: NodeJS.Global, options?: Options): void;
+export function upgradeCircus(global: NodeJS.Global, options?: Options): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+import nock from "nock/types";
+
+type FnFn = () => () => void;
+type NockTest = (title: string, fn: FnFn, timeout?: number) => void;
+
+declare global {
+    namespace jest {
+        interface It {
+            nock: NockTest;
+        }
+    }
+}
+
+type Options = {
+    writeAfterEach?: boolean;
+    loadAfterEach?: boolean;
+    nockOptions?: nock.Options;
+};
+
+export function upgradeJasmine(global: NodeJS.Global, options?: Options): void;


### PR DESCRIPTION
Types are needed to inform tsc that the jest `it` function has `it.nock`